### PR TITLE
fix: require-specific-component not handling a single prop

### DIFF
--- a/src/__tests__/require-specific-component.test.ts
+++ b/src/__tests__/require-specific-component.test.ts
@@ -63,6 +63,20 @@ test("test", () => {
         `,
       },
       {
+        name: "Require Flex component in self-closing format",
+        code: `
+          import { Box } from "@chakra-ui/react";
+
+          <Box display="flex" margin="2" paddingTop={4} />
+        `,
+        errors: [{ messageId: "requireSpecificComponent" }],
+        output: `
+          import { Box, Flex } from "@chakra-ui/react";
+
+          <Flex margin="2" paddingTop={4} />
+        `,
+      },
+      {
         name: "Require Flex component with last attribute",
         code: `
           import { Box } from "@chakra-ui/react";
@@ -102,6 +116,27 @@ test("test", () => {
         `,
       },
       {
+        name: "Require Flex component with multi-line attributes in self-closing format",
+        code: `
+          import { Box } from "@chakra-ui/react";
+
+          <Box
+            display="flex"
+            margin="2"
+            paddingTop={4}
+          />
+        `,
+        errors: [{ messageId: "requireSpecificComponent" }],
+        output: `
+          import { Box, Flex } from "@chakra-ui/react";
+
+          <Flex
+            margin="2"
+            paddingTop={4}
+          />
+        `,
+      },
+      {
         name: "Require Flex component with last attribute in multi-line attributes",
         code: `
           import { Box } from "@chakra-ui/react";
@@ -129,7 +164,7 @@ test("test", () => {
       {
         name: "Require Flex component with multi-line import",
         code: `
-          import { 
+          import {
             Box,
             Text,
             List,
@@ -139,7 +174,7 @@ test("test", () => {
         `,
         errors: [{ messageId: "requireSpecificComponent" }],
         output: `
-          import { 
+          import {
             Box,
             Text,
             List,
@@ -195,6 +230,37 @@ test("test", () => {
           <Flex>
             Hello
           </Flex>
+        `,
+      },
+      {
+        name: "Require Flex component with only one attribute in self-closing format",
+        code: `
+          import { Box } from "@chakra-ui/react";
+
+          <Box display="flex" />
+        `,
+        errors: [{ messageId: "requireSpecificComponent" }],
+        output: `
+          import { Box, Flex } from "@chakra-ui/react";
+
+          <Flex />
+        `,
+      },
+
+      {
+        name: "Require Flex component with only one attribute in self-closing and multi-line format",
+        code: `
+          import { Box } from "@chakra-ui/react";
+
+          <Box
+            display="flex"
+          />
+        `,
+        errors: [{ messageId: "requireSpecificComponent" }],
+        output: `
+          import { Box, Flex } from "@chakra-ui/react";
+
+          <Flex />
         `,
       },
     ],

--- a/src/__tests__/require-specific-component.test.ts
+++ b/src/__tests__/require-specific-component.test.ts
@@ -163,6 +163,40 @@ test("test", () => {
           <Flex margin="2" paddingTop={4}>Hello</Flex>
         `,
       },
+      {
+        name: "Require Flex component with only one attribute",
+        code: `
+          import { Box } from "@chakra-ui/react";
+
+          <Box display="flex">Hello</Box>
+        `,
+        errors: [{ messageId: "requireSpecificComponent" }],
+        output: `
+          import { Box, Flex } from "@chakra-ui/react";
+
+          <Flex>Hello</Flex>
+        `,
+      },
+      {
+        name: "Require Flex component with only one attribute in multi-line format",
+        code: `
+          import { Box } from "@chakra-ui/react";
+
+          <Box
+            display="flex"
+          >
+            Hello
+          </Box>
+        `,
+        errors: [{ messageId: "requireSpecificComponent" }],
+        output: `
+          import { Box, Flex } from "@chakra-ui/react";
+
+          <Flex>
+            Hello
+          </Flex>
+        `,
+      },
     ],
   });
 });

--- a/src/rules/require-specific-component.ts
+++ b/src/rules/require-specific-component.ts
@@ -97,7 +97,12 @@ function createFixToRemoveAttribute(
     // in case of only one attribute
     // remove attribute and extra space
     const startAttributeRangeWithSpaces = jsxNode.name.range[1];
-    const endAttributeRangeWithSpaces = jsxNode.range[1] - 1;
+    const tagCloserLength = jsxNode.selfClosing
+      ? attribute.loc.end.line <= jsxNode.loc.end.line
+        ? 3 // `\n/>`
+        : 2 // `/>`
+      : 1; // `>`
+    const endAttributeRangeWithSpaces = jsxNode.range[1] - tagCloserLength;
     return fixer.removeRange([startAttributeRangeWithSpaces, endAttributeRangeWithSpaces]);
   }
 

--- a/src/rules/require-specific-component.ts
+++ b/src/rules/require-specific-component.ts
@@ -93,6 +93,14 @@ function createFixToRemoveAttribute(
 ) {
   const attributeIndex = jsxNode.attributes.findIndex((a) => a === attribute);
 
+  if (attributeIndex === 0 && jsxNode.attributes.length === 1) {
+    // in case of only one attribute
+    // remove attribute and extra space
+    const startAttributeRangeWithSpaces = jsxNode.name.range[1];
+    const endAttributeRangeWithSpaces = jsxNode.range[1] - 1;
+    return fixer.removeRange([startAttributeRangeWithSpaces, endAttributeRangeWithSpaces]);
+  }
+
   if (attributeIndex === jsxNode.attributes.length - 1) {
     // in case of last attribute
     const prevAttribute = jsxNode.attributes[attributeIndex - 1];


### PR DESCRIPTION
Based on the issue reported in #143, this PR addresses the problem with `require-specific-component`. When the `<Box>` component has only one prop that would trigger a replacement, it fails to work properly.

Additionally, I have added two test cases to ensure the integrity of the fix.

## Input
```jsx
<Box display="flex">
  body
</Box>
```
or
```jsx
<Box
  display="flex"
>
  body
</Box>
```

## Expect
```jsx
<Flex>
  body
</Flex>
```