### PR TITLE
Improve performance by skipping ParserService generation if unnecessary

### DIFF
--- a/src/rules/props-order.ts
+++ b/src/rules/props-order.ts
@@ -66,13 +66,12 @@ export const propsOrderRule: TSESLint.RuleModule<"invalidOrder", Options> = {
 
   create: (ctx) => {
     const { report, getSourceCode, options } = ctx;
-    const parserServices = getParserServices(ctx, false);
-
     const option = options[0];
+    const parserServices = !option?.applyToAllComponents ? getParserServices(ctx, false) : undefined;
 
     return {
       JSXOpeningElement(node) {
-        if (!option?.applyToAllComponents && !isChakraElement(node, parserServices)) {
+        if (parserServices && !isChakraElement(node, parserServices)) {
           return;
         }
 

--- a/src/rules/props-order.ts
+++ b/src/rules/props-order.ts
@@ -67,11 +67,10 @@ export const propsOrderRule: TSESLint.RuleModule<"invalidOrder", Options> = {
   create: (ctx) => {
     const { report, getSourceCode, options } = ctx;
     const option = options[0];
-    const parserServices = !option?.applyToAllComponents ? getParserServices(ctx, false) : undefined;
 
     return {
       JSXOpeningElement(node) {
-        if (parserServices && !isChakraElement(node, parserServices)) {
+        if (!option?.applyToAllComponents && !isChakraElement(node, getParserServices(ctx, false))) {
           return;
         }
 

--- a/src/rules/props-shorthand.ts
+++ b/src/rules/props-shorthand.ts
@@ -44,13 +44,12 @@ export const propsShorthandRule: TSESLint.RuleModule<"enforcesShorthand" | "enfo
 
     create: (ctx) => {
       const { report, getSourceCode, options } = ctx;
-      const parserServices = getParserServices(ctx, false);
-
       const { noShorthand = false, applyToAllComponents = false } = options[0] || {};
+      const parserServices = !applyToAllComponents ? getParserServices(ctx, false) : undefined;
 
       return {
         JSXOpeningElement(node) {
-          if (!applyToAllComponents && !isChakraElement(node, parserServices)) {
+          if (parserServices && !isChakraElement(node, parserServices)) {
             return;
           }
 

--- a/src/rules/props-shorthand.ts
+++ b/src/rules/props-shorthand.ts
@@ -45,11 +45,10 @@ export const propsShorthandRule: TSESLint.RuleModule<"enforcesShorthand" | "enfo
     create: (ctx) => {
       const { report, getSourceCode, options } = ctx;
       const { noShorthand = false, applyToAllComponents = false } = options[0] || {};
-      const parserServices = !applyToAllComponents ? getParserServices(ctx, false) : undefined;
 
       return {
         JSXOpeningElement(node) {
-          if (parserServices && !isChakraElement(node, parserServices)) {
+          if (!applyToAllComponents && !isChakraElement(node, getParserServices(ctx, false))) {
             return;
           }
 


### PR DESCRIPTION
Thank you for nice rule!

I would like to make adjustments to the implementation related to 'getParserServices.' If 'applyToAllComponents' is set to true in 'props-order' or 'props-shorthand,' the parserService becomes unnecessary.

Using parserService in eslint may result in longer linting completion times compared to not using it. In my case, adopting the changes in this PR reduced a task that took 12 seconds to now complete in 8 seconds.

Plus, the parserOptions in .eslintrc will be able to be removed.


So, If 'applyToAllComponents' is set to true, it will be better to skip getParserServices call. If you have the time, I would appreciate it if you could review this PR.