### PR TITLE
Update Node.js version v22

### DIFF
--- a/.github/composite-actions/install/action.yml
+++ b/.github/composite-actions/install/action.yml
@@ -12,7 +12,7 @@ runs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: 16
+        node-version: 22
         cache: "pnpm"
 
     - name: Install dependencies


### PR DESCRIPTION
eslint v9 no longer supports Node.js v16.
https://eslint.org/docs/latest/use/migrate-to-9.0.0#drop-old-node

[To support flat config](https://github.com/yukukotani/eslint-plugin-chakra-ui/pull/223), I need to raise this first.