### PR TITLE
Flat config test using fixtures

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,8 @@ jobs:
       - name: Install TypeScript ${{ matrix.ts-version }}
         run: pnpm add typescript@${{ matrix.ts-version }}
 
+      - name: Build
+        run: pnpm run build
+
       - name: Run tests
         run: pnpm run test

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,7 +23,7 @@ importers:
         version: 18.19.70
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.19.1
-        version: 8.19.1(@typescript-eslint/parser@8.19.1)(eslint@9.18.0)(typescript@5.7.3)
+        version: 8.19.1(@typescript-eslint/parser@8.19.1(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)
       '@typescript-eslint/parser':
         specifier: ^8.19.1
         version: 8.19.1(eslint@9.18.0)(typescript@5.7.3)
@@ -41,7 +41,7 @@ importers:
         version: 6.4.0(eslint@9.18.0)
       eslint-plugin-unused-imports:
         specifier: ^4.1.4
-        version: 4.1.4(@typescript-eslint/eslint-plugin@8.19.1)(eslint@9.18.0)
+        version: 4.1.4(@typescript-eslint/eslint-plugin@8.19.1(@typescript-eslint/parser@8.19.1(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)
       globals:
         specifier: 15.14.0
         version: 15.14.0
@@ -2094,7 +2094,7 @@ snapshots:
     dependencies:
       '@types/node': 18.19.70
 
-  '@typescript-eslint/eslint-plugin@8.19.1(@typescript-eslint/parser@8.19.1)(eslint@9.18.0)(typescript@5.7.3)':
+  '@typescript-eslint/eslint-plugin@8.19.1(@typescript-eslint/parser@8.19.1(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
       '@typescript-eslint/parser': 8.19.1(eslint@9.18.0)(typescript@5.7.3)
@@ -2573,10 +2573,11 @@ snapshots:
       eslint: 9.18.0
       estraverse: 5.3.0
 
-  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.19.1)(eslint@9.18.0):
+  eslint-plugin-unused-imports@4.1.4(@typescript-eslint/eslint-plugin@8.19.1(@typescript-eslint/parser@8.19.1(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.19.1(@typescript-eslint/parser@8.19.1)(eslint@9.18.0)(typescript@5.7.3)
       eslint: 9.18.0
+    optionalDependencies:
+      '@typescript-eslint/eslint-plugin': 8.19.1(@typescript-eslint/parser@8.19.1(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)
 
   eslint-scope@8.2.0:
     dependencies:
@@ -3572,7 +3573,7 @@ snapshots:
 
   typescript-eslint@8.19.1(eslint@9.18.0)(typescript@5.7.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.19.1(@typescript-eslint/parser@8.19.1)(eslint@9.18.0)(typescript@5.7.3)
+      '@typescript-eslint/eslint-plugin': 8.19.1(@typescript-eslint/parser@8.19.1(eslint@9.18.0)(typescript@5.7.3))(eslint@9.18.0)(typescript@5.7.3)
       '@typescript-eslint/parser': 8.19.1(eslint@9.18.0)(typescript@5.7.3)
       '@typescript-eslint/utils': 8.19.1(eslint@9.18.0)(typescript@5.7.3)
       eslint: 9.18.0
@@ -3624,11 +3625,11 @@ snapshots:
 
   vite@4.5.5(@types/node@18.19.70):
     dependencies:
-      '@types/node': 18.19.70
       esbuild: 0.18.20
       postcss: 8.4.49
       rollup: 3.29.5
     optionalDependencies:
+      '@types/node': 18.19.70
       fsevents: 2.3.3
 
   vitest@0.34.6:

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,21 @@
+import path from "path";
+import { ESLint } from "eslint";
+import { describe, beforeAll, test, expect } from "vitest";
+
+describe("ESLint config fixture test", () => {
+  let eslint: ESLint;
+
+  beforeAll(() => {
+    eslint = new ESLint({
+      overrideConfigFile: path.resolve(__dirname, "./fixtures/eslint.config.mjs"),
+    });
+  });
+
+  test("valid config", async () => {
+    const results = await eslint.lintFiles([path.resolve(__dirname, "./fixtures/valid.tsx")]);
+
+    const [result] = results;
+    expect(result.errorCount).toBe(0);
+    expect(result.warningCount).toBe(0);
+  });
+});

--- a/src/__tests__/fixtures/eslint.config.mjs
+++ b/src/__tests__/fixtures/eslint.config.mjs
@@ -1,0 +1,33 @@
+import path from "path";
+import js from "@eslint/js";
+import tseslint from "typescript-eslint";
+import parser from "@typescript-eslint/parser";
+import globals from "globals";
+
+// Is it possible to view the source code without building it?
+import chakraUiPlugin from "../../../dist/index.js";
+
+export default tseslint.config(
+  {
+    languageOptions: {
+      parserOptions: {
+        parser,
+        ecmaVersion: 12,
+        sourceType: "module",
+        project: ["./tsconfig.json"],
+        tsconfigRootDir: path.resolve("./src/__tests__/fixtures"), // path.join(import.meta.diename, ".."),
+        globals: globals.browser,
+      },
+    },
+  },
+  {
+    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    files: ["**/*.tsx"],
+    plugins: {
+      "chakra-ui": chakraUiPlugin,
+    },
+    rules: {
+      ...chakraUiPlugin.configs.recommended,
+    },
+  },
+);

--- a/src/__tests__/fixtures/tsconfig.json
+++ b/src/__tests__/fixtures/tsconfig.json
@@ -2,5 +2,5 @@
   "compilerOptions": {
     "strict": true
   },
-  "include": ["file.ts", "react.tsx"]
+  "include": ["file.ts", "react.tsx", "valid.tsx"]
 }

--- a/src/__tests__/fixtures/valid.tsx
+++ b/src/__tests__/fixtures/valid.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import { Box } from "@chakra-ui/react";
+
+export const App = () => (
+  <Box pt={4} pb={4}>
+    Hello, world!
+  </Box>
+);


### PR DESCRIPTION
ref #218 

When supporting flat config, test whether lint can be executed using a plugin. 
~~This is a temporary implementation needed to migrate to flat config, and we do not intend to merge it. It is good if you can confirm that the test passes on CI.~~

After talking with @yukukotani , we decided to merge this as well.
This branch based by #223 

## How

- Create valid.tsx in fixtures and put valid code there
  - This code has no meaning, as long as it passes lint, it's fine.
- Load eslint.config.mjs from fixtures using eslint's overrideConfigFile
- Run tests using vitest

